### PR TITLE
fix: generated src/methods4docs.js has an extra line in the JSDocs for methods with no parameters

### DIFF
--- a/tools/apiDocs.js
+++ b/tools/apiDocs.js
@@ -9,6 +9,8 @@ const docsTarget = path.join(__dirname, '../src/methods4docs.js')
  * Generate dynamic methods into `docsTarget` file, to be consumed by jsDocs `generate-docs` task
  * Generated file is just for documentation purposes
  *
+ * @private
+ * @returns {undefined}
  */
 const generateMethods = () => {
   const apiConfig = OpenApi.__getApiConfig(spec)
@@ -22,12 +24,16 @@ const generateMethods = () => {
       return `   * @param {${type}} ${paramName} - ${description}`
     }).join('\n')
 
+    let paramsValue = params
+    if (params) {
+      paramsValue = `\n${params}`
+    }
+
     return `
   /**
    * ${config.summary}
    *
-   * @param {object} [parameters={}] - parameters to pass
-${params}
+   * @param {object} [parameters={}] - parameters to pass${paramsValue}
    * @returns {Promise<Response>} the response
    */
   ${config.name} (parameters = {}) {

--- a/types.d.ts
+++ b/types.d.ts
@@ -70,7 +70,6 @@ declare class CustomerProfileAPI {
      * Retrieve a list of computed attributes.
      *
      * @param {object} [parameters={}] - parameters to pass
-    
      * @returns {Promise<Response>} the response
      */
     listComputedAttributes(parameters?: any): Promise<Response>;
@@ -78,7 +77,6 @@ declare class CustomerProfileAPI {
      * Create a computed attribute.
      *
      * @param {object} [parameters={}] - parameters to pass
-    
      * @returns {Promise<Response>} the response
      */
     createComputedAttribute(parameters?: any): Promise<Response>;


### PR DESCRIPTION
see listComputedAttributes, createComputedAttribute

This generates a blank line in the JSDoc, and consequently in the `types.d.ts` file:
1. https://github.com/adobe/aio-lib-customer-profile/blob/5318953ef430b001d8c9ec0044f20b2340dfa938/types.d.ts#L73
2. https://github.com/adobe/aio-lib-customer-profile/blob/5318953ef430b001d8c9ec0044f20b2340dfa938/types.d.ts#L81

## Related Issue

Relates to #5 ?

## How Has This Been Tested?

npm run generate-docs

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
