### PR TITLE
fix: GET calls fail with swagger client because of empty body in calls

### DIFF
--- a/src/openApiSDK.js
+++ b/src/openApiSDK.js
@@ -85,6 +85,10 @@ class OpenApi {
       ...parameters
     }
 
+    if(config.method === 'get') {
+      requestOptions.requestBody = null
+    }
+
     if (config.method === 'post' && !apiParams['Content-Type']) {
       apiParams['Content-Type'] = 'application/json'
     }

--- a/src/openApiSDK.js
+++ b/src/openApiSDK.js
@@ -85,7 +85,7 @@ class OpenApi {
       ...parameters
     }
 
-    if(config.method === 'get') {
+    if (config.method === 'get') {
       requestOptions.requestBody = null
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -123,7 +123,7 @@ test('getAccessEntities', async () => {
     'x-gw-ims-org-id': 'test-iMSOrgId',
     'x-request-id': 1
   }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'Entities.get_access_entities',
@@ -160,7 +160,7 @@ test('getAccessEntities sandbox', async () => {
     'x-gw-ims-org-id': 'test-iMSOrgId',
     'x-request-id': 1
   }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'Entities.get_access_entities',
@@ -180,7 +180,7 @@ test('getProfile', async () => {
     'x-request-id': 1
   }
 
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'Entities.get_access_entities',
@@ -200,7 +200,7 @@ test('getExperienceEvents', async () => {
     'x-gw-ims-org-id': 'test-iMSOrgId',
     'x-request-id': 1
   }
-  const apiOptions = createSwaggerOptions()
+  const apiOptions = createSwaggerOptions({ body: null })
 
   return expect(() => standardTest({
     fullyQualifiedApiName: 'Entities.get_access_entities',


### PR DESCRIPTION
Fixes #29 
Fixed issue with latest swagger client throwing error for empty body for get calls.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
