### PR TITLE
fix: e2e tests

### DIFF
--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -43,7 +43,7 @@ test('bad access token', async () => {
   const promise = _sdkClient.getAccessEntities(requiredParam)
 
   // just match the error message
-  return expect(promise).rejects.toThrow('401')
+  await expect(promise).rejects.toThrow('401')
 })
 
 test('bad api key', async () => {
@@ -51,7 +51,7 @@ test('bad api key', async () => {
   const promise = _sdkClient.getAccessEntities(requiredParam)
 
   // just match the error message
-  return expect(promise).rejects.toThrow('[CustomerProfileAPISDK:ERROR_ENTITIES] Error 403 - Forbidden ({"error_code":"403003","message":"Api Key is invalid"})')
+  await expect(promise).rejects.toThrow('[CustomerProfileAPISDK:ERROR_ENTITIES] Error 403 - Forbidden ({"error_code":"403003","message":"Api Key is invalid"})')
 })
 
 test('getAccessEntities API', async () => {

--- a/spec/api.json
+++ b/spec/api.json
@@ -5227,7 +5227,7 @@
   },
   "servers": [
     {
-      "url": "//platform.adobe.io/data/core/ups"
+      "url": "https://platform.adobe.io/data/core/ups"
     }
   ],
   "security": [


### PR DESCRIPTION
## Description

The server url in the swagger spec was protocol relative. It seems like swagger-client is now doing URL validation and the relative url did not pass, causing failures in the e2e tests

Also tests were timing out locally for me. I think this was because the calls to `expect()` with the promises were not being awaited, so I've changed that as well

## Related Issue

## Motivation and Context

## How Has This Been Tested?

`npm run e2e` locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
